### PR TITLE
Add linting tools and update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,11 @@
----
 name: Test
-
 on: pull_request
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
-  DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG }}
   MISE_DEBUG: ${{ secrets.ACTIONS_STEP_DEBUG && 1 || 0 }}
-  MISE_GITHUB_TOKEN: ${{ github.token }}
-
+  MISE_ENV: ci
 jobs:
   test:
     strategy:
@@ -21,4 +19,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v3
+      - run: mise run bootstrap
       - run: mise run test

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ xcuserdata/
 # Python
 
 # uv
-#.uv-cache
+.uv-cache
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,7 @@
 {
 	"recommendations": [
-		"editorconfig.editorconfig",
-		"github.vscode-github-actions",
-		"redhat.vscode-yaml",
-		"swiftlang.swift-vscode",
-		"tamasfe.even-better-toml",
-		"timonwong.shellcheck"
+		"astral-sh.ty",
+		"hverlin.mise-vscode",
+		"charliermarsh.ruff",
 	]
 }

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,40 @@
+amends "package://github.com/jdx/hk/releases/download/v1.27.0/hk@1.27.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.27.0/hk@1.27.0#/Builtins.pkl"
+
+fail_fast = false
+env {
+	["HK_MISE"] = "true"
+}
+
+local linters = new Mapping<String, Step> {
+	["actionlint"] = Builtins.actionlint
+	["mise"] = Builtins.mise
+	["pkl"] = Builtins.pkl
+	["ruff_format"] = Builtins.ruff_format
+	["ruff"] = Builtins.ruff
+	["tombi_format"] = Builtins.tombi_format
+	["tombi"] = Builtins.tombi
+	["yamlfmt"] = Builtins.yamlfmt
+	["yamllint"] = Builtins.yamllint
+
+	// Generic linters
+	["fix-smart-quotes"] = Builtins.fix_smart_quotes
+	["mixed-line-ending"] = Builtins.mixed_line_ending
+	["newlines"] = Builtins.newlines
+	["trailing-whitespace"] = Builtins.trailing_whitespace
+}
+
+hooks {
+	["fix"] {
+		fix = true
+		steps = linters
+	}
+	["check"] {
+		steps = linters
+	}
+	["pre-commit"] {
+		fix = true
+		stash = true
+		steps = linters
+	}
+}

--- a/mise.ci.toml
+++ b/mise.ci.toml
@@ -1,0 +1,5 @@
+[settings.python]
+uv_venv_auto = false
+
+[env]
+_.python.venv = { path = ".venv", create = false }

--- a/mise.toml
+++ b/mise.toml
@@ -1,25 +1,22 @@
 [settings]
 activate_aggressive = true
 experimental = true
-python.uv_venv_auto = true
 
-[env]
-UV_CACHE_DIR = "{{cwd}}/.uv-cache"
-PYTHONPATH = "src"
+[settings.python]
+uv_venv_auto = true
 
 [tools]
+pkl = "latest"
 python = { version = "latest", uv = true }
 uv = "latest"
-
-[hooks]
-preinstall = "mise plugins update"
-postinstall = "mise run bootstrap"
+hk = "latest"
+yamllint = "latest"
+actionlint = "latest"
+tombi = "latest"
+yamlfmt = "latest"
 
 [tasks.bootstrap]
-run = [
-	"uv --version",
-	"uv sync",
-]
+run = ["hk install --mise", "uv sync"]
 
 [tasks.deps-upgrade]
 run = "uv sync --upgrade"
@@ -37,16 +34,14 @@ run = "uv run pytest"
 
 [tasks.clean]
 run = [
-	"rm -rf dist",
-	"rm -rf build",
-	"rm -rf *.egg-info",
-	"rm -rf .pytest_cache",
-	"find . -name '__pycache__' -type d -prune -exec rm -rf {} +",
+  "rm -rf dist",
+  "rm -rf build",
+  "rm -rf .ruff_cache",
+  "rm -rf src/getart.egg-info",
+  "rm -rf .pytest_cache",
+  "find . -name '__pycache__' -type d -prune -exec rm -rf {} +",
 ]
 
 [tasks.nuke]
 depends = ["clean"]
-run = [
-	"rm -rf .venv",
-	"uv cache prune",
-]
+run = ["rm -rf .venv", "uv cache prune"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 requires-python = ">=3.14"
 authors = [{ name = "Isaac Halvorson" }]
 dependencies = [
-    "beautifulsoup4",
-    "httpx",
+  "beautifulsoup4",
+  "httpx",
 ]
 
 [project.scripts]
@@ -15,7 +15,10 @@ getart = "getart.cli:main"
 
 [dependency-groups]
 dev = [
-    "pytest",
+  "pytest",
+  "ruff",
+  "ruff_format",
+  "ty",
 ]
 
 [tool.uv]

--- a/src/getart/cli.py
+++ b/src/getart/cli.py
@@ -48,6 +48,7 @@ def normalize_url(candidate: str) -> str:
         return normalized.geturl()
     return candidate
 
+
 def _open_asset(asset_url: str) -> None:
     try:
         webbrowser.open(asset_url)
@@ -69,7 +70,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     normalized_url = normalize_url(args.url)
 
     try:
-        assets: ArtworkAssets = fetch_artwork_assets(normalized_url, timeout=args.timeout)
+        assets: ArtworkAssets = fetch_artwork_assets(
+            normalized_url, timeout=args.timeout
+        )
     except GetArtError as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/src/getart/core.py
+++ b/src/getart/core.py
@@ -97,7 +97,9 @@ class ServerData:
                 dictionary = video_artwork.get("dictionary")
                 if not isinstance(dictionary, dict):
                     continue
-                motion_detail = dictionary.get("motionDetailSquare") or dictionary.get("motionDetail")
+                motion_detail = dictionary.get("motionDetailSquare") or dictionary.get(
+                    "motionDetail"
+                )
                 if not isinstance(motion_detail, dict):
                     continue
                 video = motion_detail.get("video")
@@ -107,7 +109,9 @@ class ServerData:
 
 
 class AppleMusicClient:
-    def __init__(self, *, timeout: float = 10.0, transport: BaseTransport | None = None) -> None:
+    def __init__(
+        self, *, timeout: float = 10.0, transport: BaseTransport | None = None
+    ) -> None:
         self._client = httpx.Client(
             timeout=timeout,
             headers=DEFAULT_HEADERS,
@@ -134,10 +138,14 @@ class AppleMusicClient:
         soup = BeautifulSoup(html, "html.parser")
         element = soup.find(id="serialized-server-data")
         if element is None:
-            raise ServerDataNotFoundError("serialized-server-data element not present in HTML.")
+            raise ServerDataNotFoundError(
+                "serialized-server-data element not present in HTML."
+            )
         json_text = element.string or element.text
         if not json_text:
-            raise ServerDataNotFoundError("serialized-server-data element contained no JSON.")
+            raise ServerDataNotFoundError(
+                "serialized-server-data element contained no JSON."
+            )
         return ServerData.from_json(json_text)
 
     def resolve_video_url(self, playlist_url: str) -> Optional[str]:

--- a/tests/test_server_data.py
+++ b/tests/test_server_data.py
@@ -13,7 +13,9 @@ def load_fixture(name: str) -> str:
 
 
 def test_image_artwork_url() -> None:
-    server_data = ServerData.from_json(load_fixture("test-json-no-video-only-used-data.json"))
+    server_data = ServerData.from_json(
+        load_fixture("test-json-no-video-only-used-data.json")
+    )
     assert server_data.image_artwork_url() == (
         "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/c5/9a/d0/"
         "c59ad049-d5a4-8df2-8564-238472cf497a/24UMGIM28458.rgb.jpg/3000x3000bb.jpg"
@@ -21,7 +23,9 @@ def test_image_artwork_url() -> None:
 
 
 def test_video_playlist_url() -> None:
-    server_data = ServerData.from_json(load_fixture("test-json-with-video-only-used-data.json"))
+    server_data = ServerData.from_json(
+        load_fixture("test-json-with-video-only-used-data.json")
+    )
     assert (
         server_data.video_playlist_url()
         == "https://mvod.itunes.apple.com/itunes-assets/HLSVideo221/v4/41/85/ad/"

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
+    { name = "ruff-format" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -66,7 +69,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest" }]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "ruff-format" },
+    { name = "ty" },
+]
 
 [[package]]
 name = "h11"
@@ -152,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -161,18 +169,91 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/08/52232a877978dd8f9cf2aeddce3e611b40a63287dfca29b6b8da791f5e8d/ruff-0.14.10.tar.gz", hash = "sha256:9a2e830f075d1a42cd28420d7809ace390832a490ed0966fe373ba288e77aaf4", size = 5859763, upload-time = "2025-12-18T19:28:57.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/01/933704d69f3f05ee16ef11406b78881733c186fe14b6a46b05cfcaf6d3b2/ruff-0.14.10-py3-none-linux_armv6l.whl", hash = "sha256:7a3ce585f2ade3e1f29ec1b92df13e3da262178df8c8bdf876f48fa0e8316c49", size = 13527080, upload-time = "2025-12-18T19:29:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/df/58/a0349197a7dfa603ffb7f5b0470391efa79ddc327c1e29c4851e85b09cc5/ruff-0.14.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:674f9be9372907f7257c51f1d4fc902cb7cf014b9980152b802794317941f08f", size = 13797320, upload-time = "2025-12-18T19:29:02.571Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/82/36be59f00a6082e38c23536df4e71cdbc6af8d7c707eade97fcad5c98235/ruff-0.14.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d85713d522348837ef9df8efca33ccb8bd6fcfc86a2cde3ccb4bc9d28a18003d", size = 12918434, upload-time = "2025-12-18T19:28:51.202Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/00/45c62a7f7e34da92a25804f813ebe05c88aa9e0c25e5cb5a7d23dd7450e3/ruff-0.14.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6987ebe0501ae4f4308d7d24e2d0fe3d7a98430f5adfd0f1fead050a740a3a77", size = 13371961, upload-time = "2025-12-18T19:29:04.991Z" },
+    { url = "https://files.pythonhosted.org/packages/40/31/a5906d60f0405f7e57045a70f2d57084a93ca7425f22e1d66904769d1628/ruff-0.14.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:16a01dfb7b9e4eee556fbfd5392806b1b8550c9b4a9f6acd3dbe6812b193c70a", size = 13275629, upload-time = "2025-12-18T19:29:21.381Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/60/61c0087df21894cf9d928dc04bcd4fb10e8b2e8dca7b1a276ba2155b2002/ruff-0.14.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7165d31a925b7a294465fa81be8c12a0e9b60fb02bf177e79067c867e71f8b1f", size = 14029234, upload-time = "2025-12-18T19:29:00.132Z" },
+    { url = "https://files.pythonhosted.org/packages/44/84/77d911bee3b92348b6e5dab5a0c898d87084ea03ac5dc708f46d88407def/ruff-0.14.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c561695675b972effb0c0a45db233f2c816ff3da8dcfbe7dfc7eed625f218935", size = 15449890, upload-time = "2025-12-18T19:28:53.573Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/36/480206eaefa24a7ec321582dda580443a8f0671fdbf6b1c80e9c3e93a16a/ruff-0.14.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4bb98fcbbc61725968893682fd4df8966a34611239c9fd07a1f6a07e7103d08e", size = 15123172, upload-time = "2025-12-18T19:29:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/38/68e414156015ba80cef5473d57919d27dfb62ec804b96180bafdeaf0e090/ruff-0.14.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f24b47993a9d8cb858429e97bdf8544c78029f09b520af615c1d261bf827001d", size = 14460260, upload-time = "2025-12-18T19:29:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/19/9e050c0dca8aba824d67cc0db69fb459c28d8cd3f6855b1405b3f29cc91d/ruff-0.14.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59aabd2e2c4fd614d2862e7939c34a532c04f1084476d6833dddef4afab87e9f", size = 14229978, upload-time = "2025-12-18T19:29:11.32Z" },
+    { url = "https://files.pythonhosted.org/packages/51/eb/e8dd1dd6e05b9e695aa9dd420f4577debdd0f87a5ff2fedda33c09e9be8c/ruff-0.14.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:213db2b2e44be8625002dbea33bb9c60c66ea2c07c084a00d55732689d697a7f", size = 14338036, upload-time = "2025-12-18T19:29:09.184Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/12/f3e3a505db7c19303b70af370d137795fcfec136d670d5de5391e295c134/ruff-0.14.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b914c40ab64865a17a9a5b67911d14df72346a634527240039eb3bd650e5979d", size = 13264051, upload-time = "2025-12-18T19:29:13.431Z" },
+    { url = "https://files.pythonhosted.org/packages/08/64/8c3a47eaccfef8ac20e0484e68e0772013eb85802f8a9f7603ca751eb166/ruff-0.14.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1484983559f026788e3a5c07c81ef7d1e97c1c78ed03041a18f75df104c45405", size = 13283998, upload-time = "2025-12-18T19:29:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/12/84/534a5506f4074e5cc0529e5cd96cfc01bb480e460c7edf5af70d2bcae55e/ruff-0.14.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c70427132db492d25f982fffc8d6c7535cc2fd2c83fc8888f05caaa248521e60", size = 13601891, upload-time = "2025-12-18T19:28:55.811Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/14c916087d8598917dbad9b2921d340f7884824ad6e9c55de948a93b106d/ruff-0.14.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5bcf45b681e9f1ee6445d317ce1fa9d6cba9a6049542d1c3d5b5958986be8830", size = 14336660, upload-time = "2025-12-18T19:29:16.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
+    { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
+]
+
+[[package]]
+name = "ruff-format"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/ae/5767b436b41af8add7432286fce65a489a4db88ed090fb66275fa0076cd3/ruff_format-0.4.1.tar.gz", hash = "sha256:2aff271154b088ee131cef63a92afbc4cdc3905acf03d279c4a8aa3f6b3fb564", size = 15622, upload-time = "2025-10-28T18:31:39.817Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/0f/47755cda55e7d55211e43d5de61d80bd75d1c0f63d3df996d53d5cfbe1c5/ruff_format-0.4.1-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:60c5aca1dc8b0fa5133bd7983035999cce03daf97da24668945d69114c630dc8", size = 2153211, upload-time = "2025-10-28T18:31:26.698Z" },
+    { url = "https://files.pythonhosted.org/packages/10/03/daeff0742bc47c2fc56d250049bdf6b81074d23dcab3b9486c9c33857cb1/ruff_format-0.4.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f1eb8a30f2c03d27764a2985b56b2053d2f2e74a65cc98550edbc71aa4bfbb3c", size = 2090816, upload-time = "2025-10-28T18:31:24.175Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f0/64525240a46f1bdc9e7cf7c53342ab271c2ab22cd10f4c016153b6582ecb/ruff_format-0.4.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae67a0d1d9b6826deefbbf3c326bcf9a4d4e6cd46536f8f7d33d2cd06bc79b97", size = 2280121, upload-time = "2025-10-28T18:31:06.578Z" },
+    { url = "https://files.pythonhosted.org/packages/82/56/192aaa9e3ea2003f1da44cf3d766b93325dfae41ffbdc0133506456af06c/ruff_format-0.4.1-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7edcbaed5c66e46bf1c57efa93151624cfe6eb7f2af0864fe6194da4dad01524", size = 2226372, upload-time = "2025-10-28T18:31:09.988Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/8759d7525b394b78dfa8484eba64db8373293f655e42a2ea48bf18a4028c/ruff_format-0.4.1-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0151c72b3f4a8eb2dbbcee360e68581676e7e490cd3cc4ba098fb96a831659db", size = 3139010, upload-time = "2025-10-28T18:31:12.958Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/70/5c52d0dd2d8d5287b4e27724f022f7229d4c45fe0f75f53d659f67d408f6/ruff_format-0.4.1-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:00e0a83bd9a7acc8d50a63d8057441085d7498e94b130377082bea4cc57fdc62", size = 2437646, upload-time = "2025-10-28T18:31:15.862Z" },
+    { url = "https://files.pythonhosted.org/packages/66/99/b89a34911e7287505e13efa487f2488e9a537d2429b37f465c94ea6612bf/ruff_format-0.4.1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9086e8efea0925699b1c2a649922b936356d88f64c36b859aac2ed6033991042", size = 2338267, upload-time = "2025-10-28T18:31:21.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/02/92178e6b14b93f7dfed57c6c5f249ad7b858218aaf55f303f932d04d6459/ruff_format-0.4.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:be26579b974401f8e6cadd4837bdb4033696740758973c43dc470bd8404abf0a", size = 2408411, upload-time = "2025-10-28T18:31:18.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/61f41a959595adfb00f60c9a8fcbb0b5d32c69d32cafbdf807d38cd543a9/ruff_format-0.4.1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:95f3c7dee3067616aaeb1d3e08968ea1d71e030c1c9704524ad91149df1cbda2", size = 2460360, upload-time = "2025-10-28T18:31:30.19Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1e/d32bea94d19e1a5df9cbb581ffe46b25d72f2f13dc380ebc301366dd0791/ruff_format-0.4.1-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c00576aac8e66548d778116be4e8d83abf994303c9426d2d9fa3ee47e952ebeb", size = 2492780, upload-time = "2025-10-28T18:31:32.804Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/71/b6d9b84cbd716a2c968c9cfe365070d2f5411e448287ed925d9c8786bade/ruff_format-0.4.1-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:15ad2649a213a78f907893a42712381e7a0f66107e5d5f48e9891657a5147852", size = 2498606, upload-time = "2025-10-28T18:31:35.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/2e/3f40d244fdd5bdbe993f55d46e2285900d4b03f0a50fdcd8280ce8635209/ruff_format-0.4.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a322cd9062664d0461efc804418b349c30a68e1e58c8794b1e9b28aa57ee02a2", size = 2509832, upload-time = "2025-10-28T18:31:38.757Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/3253d7f4354a104e1e79110d740f4293042fd399981c59653a8353dc450a/ruff_format-0.4.1-cp38-abi3-win32.whl", hash = "sha256:66524a2088eb0f2bb95f297ad8bda2bec0143e9d690bbce76a2b326b4e668968", size = 1823361, upload-time = "2025-10-28T18:31:44.07Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2d/7f20db74ff5156900852077026771bd20f3ca1ba2a4987d98e3385c13ad8/ruff_format-0.4.1-cp38-abi3-win_amd64.whl", hash = "sha256:3f5360ebfe9465c4bb803dd69c6cdc38610860ee9087b40ae038a595c4779653", size = 1927799, upload-time = "2025-10-28T18:31:41.716Z" },
 ]
 
 [[package]]
 name = "soupsieve"
-version = "2.8"
+version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/23/adf3796d740536d63a6fbda113d07e60c734b6ed5d3058d1e47fc0495e47/soupsieve-2.8.1.tar.gz", hash = "sha256:4cf733bc50fa805f5df4b8ef4740fc0e0fa6218cf3006269afd3f9d6d80fd350", size = 117856, upload-time = "2025-12-18T13:50:34.655Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f3/b67d6ea49ca9154453b6d70b34ea22f3996b9fa55da105a79d8732227adc/soupsieve-2.8.1-py3-none-any.whl", hash = "sha256:a11fe2a6f3d76ab3cf2de04eb339c1be5b506a8a47f2ceb6d139803177f85434", size = 36710, upload-time = "2025-12-18T13:50:33.267Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/0d/ed8a66c10ca2ec5d80d683f945c1d0ef6b030905baca4cc4ec5082c62a9f/ty-0.0.6.tar.gz", hash = "sha256:ecf195494fe442daac961ccbf1be286471b92a690adf1ae86de252cc0ce766e8", size = 4818224, upload-time = "2025-12-23T22:15:47.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/95/d5334c41e006242211719c69625e622b4cbab4eaa2c1da485f6f5d64da56/ty-0.0.6-py3-none-linux_armv6l.whl", hash = "sha256:02a600a9d8e5489097e7566f048d1be471bcd17d52f9236d659b3dd3d8bce3bd", size = 9865948, upload-time = "2025-12-23T22:16:08.429Z" },
+    { url = "https://files.pythonhosted.org/packages/91/11/e0ef9b8e56c6fbfa6c3cda1dcfde21d670e75bce142233a748542f1969da/ty-0.0.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4e4654bf04bd517e02a2afe105ce86b62815900db7cca2d213284a0573635103", size = 9689798, upload-time = "2025-12-23T22:16:10.069Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/39/8afc6421ac283b23854b4e08d6c498e33ba2f8f1c2a0c669da1852191451/ty-0.0.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4bfdaa6f54a9123d9a5dd094596fc671015ec0f3ef2fad14494246c4654281bc", size = 9205779, upload-time = "2025-12-23T22:16:06.755Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/f6cb1781ad7cc55bd03264979cce97aa761064bd9e2959e5334dc9ee5d38/ty-0.0.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b42b1abc068c5012f60618139852f02f6d2c566979edf2306ef1ac15dd9ee4c4", size = 9693432, upload-time = "2025-12-23T22:15:54.679Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a7/2fb7f711ccbe2038b922b6b9daaddabad9df81b67a23b93fb82bbf59ae68/ty-0.0.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a890c1145ace0e16e3d1be4df8272ed5915ac35bd75e4a0e1c53001ca090713", size = 9668051, upload-time = "2025-12-23T22:16:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4e/5bba4863f448f1bd593c01bb9616349c56ab4ec3c076cff3c0f840044875/ty-0.0.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f65b5d1505aa8a6ffb9dad673a3aa11c77411baa132d32b62e39662dafcb94ee", size = 10099592, upload-time = "2025-12-23T22:16:12.294Z" },
+    { url = "https://files.pythonhosted.org/packages/66/83/0c417c213003e21c976af8e897abc2565811d90935a820348d9507de5b66/ty-0.0.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:7bb4d332d02e9b4abe3cbaa2f53fd0fe4c8d12b187a8aa398b658ba2f4f9f5a7", size = 10987979, upload-time = "2025-12-23T22:15:52.502Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2f/82ba22fc1f2f0edd123505c58a1736d83b9fd9fcf670357f68f4b1917f52/ty-0.0.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9331ba14dd90fa6f3650786d3fa5a08a4382e4e20a0879316843d09fc739f2a4", size = 10690933, upload-time = "2025-12-23T22:16:14.34Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/1a/d3e40753820b40218af0d9c6945b347ca524dd57dbe1a8d0160e980e9a91/ty-0.0.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c8bb30bc8e45fb5caba70bb63e338027019167a7f1e733a15f27eaabed28522", size = 10521677, upload-time = "2025-12-23T22:15:50.157Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c8/cd8c34e99a12db62fee1b715482242d712b421936e0a94e221b99ef0f0a3/ty-0.0.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e27661ea96e60320e12a660958c39a6630d111ecac0028cf164003c966ef758c", size = 10226973, upload-time = "2025-12-23T22:15:59.088Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c1/27ae51eab2cfe9177967c89b416b6beaa5100036b719d9b1621eb1b0a8c0/ty-0.0.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:36f85148acec63ac87a4e49139f50f0add95fdfcef171cc8973a530c72ca8e27", size = 9675931, upload-time = "2025-12-23T22:16:21.164Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/b1a7b223a9519b4e8b4ae31d1b092c79700e3977981abb1da07321bb7d88/ty-0.0.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aa0988a3720882c255fa173753746d90bd9d82adebb1a00a561e0a04bbca1cd4", size = 9685617, upload-time = "2025-12-23T22:15:57.046Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a7/d86ca25d4f0e9c666dcd7053190c45f2c34219525fc4c586df667e65e38b/ty-0.0.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:48783f31a758bcb959e3ed58464872aee4b3f40da3b6b84fbc3bb450567232bd", size = 9834627, upload-time = "2025-12-23T22:16:17.708Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/21/76e9e7f507b412533ec000554731abd94a435bfc8a9bfadbde1d88d34914/ty-0.0.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b24660cdd84740dce548af4d0a821f2c76f8a59a7b2dc284c52e0d3ef0829f39", size = 10330699, upload-time = "2025-12-23T22:16:15.969Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ee/17e1d8dd2d75a175178cc3df776b9fb7ce7823975582cbb6f8f27e015f80/ty-0.0.6-py3-none-win32.whl", hash = "sha256:a53683a8e3eec225b00be402372139868bb29c15ddb3a0ba8ad7d38ec5196785", size = 9274125, upload-time = "2025-12-23T22:16:04.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ec/aa8dd57044319b857b5526178848ae6b94fd990135ef13d4d308f9a82736/ty-0.0.6-py3-none-win_amd64.whl", hash = "sha256:e6f840220462a2122c171440f5fc989d0125175290d636c5436eaa736bbc83b1", size = 10131668, upload-time = "2025-12-23T22:16:19.392Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fe/bb0783213193a3294119d3d12b0454e59d7c23b3d1592f04a9711d458289/ty-0.0.6-py3-none-win_arm64.whl", hash = "sha256:8e595ece22a130d32532b0c18808db98a258227dd53230968f45c6cbf040ea50", size = 9643743, upload-time = "2025-12-23T22:16:02.56Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #7

### TL;DR

Added code linting and formatting tools with HK integration for consistent code style.

### What changed?

- Added HK configuration file (`hk.pkl`) with linters for Python, YAML, and GitHub Actions
- Updated VSCode extension recommendations to include linting/formatting tools
- Added development dependencies for `ruff`, `ruff_format`, and `ty` in `pyproject.toml`
- Added new tools to `mise.toml` including `pkl`, `hk`, `yamllint`, `actionlint`, `tombi`, and `yamlfmt`
- Fixed GitHub Actions workflow by simplifying the `MISE_DEBUG` environment variable
- Reformatted Python code with consistent line breaks and indentation

### How to test?

1. Run `mise install` to get the new tools
2. Test the linting with `hk check`
3. Test auto-formatting with `hk fix`
4. Verify the GitHub Actions workflow runs correctly on a PR

### Why make this change?

This change establishes a consistent code style and adds automated linting/formatting to improve code quality. By integrating HK as a pre-commit hook, we ensure all code follows the same standards before being committed. The addition of specialized linters for different file types (Python, YAML, TOML) helps maintain consistency across the entire codebase.